### PR TITLE
Remove “t” after safety (urgency 4)  Fixed #171

### DIFF
--- a/ORCycle/res/values/strings.xml
+++ b/ORCycle/res/values/strings.xml
@@ -605,7 +605,7 @@ Please use ORcycle to log new trip purposes, routes, or safety locations.</strin
         <item>Safety Issue (urgency 1)</item>
         <item>Safety Issue (urgency 2)</item>
         <item>Safety Issue (urgency 3)</item>
-        <item>Safety Issue (urgency 4)t</item>
+        <item>Safety Issue (urgency 4)</item>
         <item>Safety Issue (urgency 5)</item>
     </string-array>
 


### PR DESCRIPTION
Remove “t” after safety (urgency 4)  Fixed #171
